### PR TITLE
Add PUT functionality to Courses backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CourseController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CourseController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 import edu.ucsb.cs156.happiercows.entities.Course;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.models.CourseDTO;
 import edu.ucsb.cs156.happiercows.repositories.CourseRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,8 +47,8 @@ public class CourseController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("")
     public Course postCourse(
-            @Parameter(name = "course") @RequestBody Course course) {
-        Course savedCourse = courseRepository.save(course);
+            @Parameter(name = "course") @RequestBody CourseDTO courseDTO) {
+        Course savedCourse = courseRepository.save(courseDTO.toCourse());
         return savedCourse;
     }
 
@@ -56,7 +57,7 @@ public class CourseController extends ApiController {
     @PutMapping("/{id}")
     public Course updateCourse(
             @Parameter(name = "id") @PathVariable Long id,
-            @Parameter(name = "course") @RequestBody Course incomingCourse) {
+            @Parameter(name = "course") @RequestBody CourseDTO incomingCourse) {
         Course course = courseRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, id));
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CourseDTO.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CourseDTO.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import edu.ucsb.cs156.happiercows.entities.Course;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class CourseDTO {
+    private String code;
+    private String name;
+    private String term;
+
+    public Course toCourse() {
+        return Course.builder()
+                .code(code)
+                .name(name)
+                .term(term)
+                .build();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CourseControllerTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Course;
+import edu.ucsb.cs156.happiercows.models.CourseDTO;
 import edu.ucsb.cs156.happiercows.repositories.CourseRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ public class CourseControllerTests extends ControllerTestCase {
 
     @Test
     public void logged_out_users_cannot_post() throws Exception {
-        Course course = Course.builder()
+        CourseDTO courseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("F24")
@@ -53,13 +54,13 @@ public class CourseControllerTests extends ControllerTestCase {
         mockMvc.perform(post("/api/course")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(course)))
+                .content(mapper.writeValueAsString(courseDTO)))
                 .andExpect(status().is(403));
     }
 
     @Test
     public void logged_out_users_cannot_put() throws Exception {
-        Course course = Course.builder()
+        CourseDTO courseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("F24")
@@ -68,7 +69,7 @@ public class CourseControllerTests extends ControllerTestCase {
         mockMvc.perform(put("/api/course/1")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(course)))
+                .content(mapper.writeValueAsString(courseDTO)))
                 .andExpect(status().is(403));
     }
 
@@ -119,7 +120,7 @@ public class CourseControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_user_cannot_post_course() throws Exception {
-        Course course = Course.builder()
+        CourseDTO courseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("F24")
@@ -128,14 +129,14 @@ public class CourseControllerTests extends ControllerTestCase {
         mockMvc.perform(post("/api/course")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(course)))
+                .content(mapper.writeValueAsString(courseDTO)))
                 .andExpect(status().is(403));
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_user_cannot_put_course() throws Exception {
-        Course course = Course.builder()
+        CourseDTO courseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("F24")
@@ -144,7 +145,7 @@ public class CourseControllerTests extends ControllerTestCase {
         mockMvc.perform(put("/api/course/1")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(course)))
+                .content(mapper.writeValueAsString(courseDTO)))
                 .andExpect(status().is(403));
     }
 
@@ -185,7 +186,7 @@ public class CourseControllerTests extends ControllerTestCase {
     @Test
     public void admin_can_post_new_course() throws Exception {
 
-        Course course = Course.builder()
+        CourseDTO courseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("F24")
@@ -198,15 +199,20 @@ public class CourseControllerTests extends ControllerTestCase {
                 .term("F24")
                 .build();
 
-        when(courseRepository.save(course)).thenReturn(savedCourse);
+        when(courseRepository.save(any(Course.class))).thenReturn(savedCourse);
 
         MvcResult response = mockMvc.perform(post("/api/course")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(course)))
+                .content(mapper.writeValueAsString(courseDTO)))
                 .andExpect(status().isOk()).andReturn();
 
-        verify(courseRepository, times(1)).save(course);
+        ArgumentCaptor<Course> courseCaptor = ArgumentCaptor.forClass(Course.class);
+        verify(courseRepository, times(1)).save(courseCaptor.capture());
+        Course savedArgument = courseCaptor.getValue();
+        assertEquals(courseDTO.getCode(), savedArgument.getCode());
+        assertEquals(courseDTO.getName(), savedArgument.getName());
+        assertEquals(courseDTO.getTerm(), savedArgument.getTerm());
         String expectedJson = mapper.writeValueAsString(savedCourse);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
@@ -223,7 +229,7 @@ public class CourseControllerTests extends ControllerTestCase {
                 .term("F20")
                 .build();
 
-        Course updatedCourse = Course.builder()
+        CourseDTO updatedCourseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("W25")
@@ -242,7 +248,7 @@ public class CourseControllerTests extends ControllerTestCase {
         MvcResult response = mockMvc.perform(put("/api/course/7")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(updatedCourse)))
+                .content(mapper.writeValueAsString(updatedCourseDTO)))
                 .andExpect(status().isOk()).andReturn();
 
         verify(courseRepository, times(1)).findById(7L);
@@ -250,9 +256,9 @@ public class CourseControllerTests extends ControllerTestCase {
         verify(courseRepository, times(1)).save(courseCaptor.capture());
         Course savedArgument = courseCaptor.getValue();
         assertEquals(7L, savedArgument.getId());
-        assertEquals(updatedCourse.getCode(), savedArgument.getCode());
-        assertEquals(updatedCourse.getName(), savedArgument.getName());
-        assertEquals(updatedCourse.getTerm(), savedArgument.getTerm());
+        assertEquals(updatedCourseDTO.getCode(), savedArgument.getCode());
+        assertEquals(updatedCourseDTO.getName(), savedArgument.getName());
+        assertEquals(updatedCourseDTO.getTerm(), savedArgument.getTerm());
         String expectedJson = mapper.writeValueAsString(savedCourse);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
@@ -261,7 +267,7 @@ public class CourseControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void admin_cannot_put_course_when_it_does_not_exist() throws Exception {
-        Course updatedCourse = Course.builder()
+        CourseDTO updatedCourseDTO = CourseDTO.builder()
                 .code("CMPSC 156")
                 .name("Advanced App Programming")
                 .term("W25")
@@ -272,7 +278,7 @@ public class CourseControllerTests extends ControllerTestCase {
         mockMvc.perform(put("/api/course/7")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(updatedCourse)))
+                .content(mapper.writeValueAsString(updatedCourseDTO)))
                 .andExpect(status().isNotFound());
 
         verify(courseRepository, times(1)).findById(7L);


### PR DESCRIPTION
Merge after #31 
Dokku Link: https://happycows-mihir-s-05-put-courses.dokku-16.cs.ucsb.edu
## Overview
This PR adds PUT functionality to the Courses database for signed in admins only. 

## Screenshots (Optional)
<img width="1763" height="1477" alt="image" src="https://github.com/user-attachments/assets/83d98341-afd9-4284-b692-04555bd2b61a" />

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Sign in with an admin account.
4. Go to Swagger.
5. Create a course using the POST functionality.
6. View its information with one of the GET commands.
7. Use the PUT command to change the course.
8. View the changes with the GET functionality.

## Tests
<!--Add any additional tests or required tests-->
- [ ✓] Backend Unit tests (`mvn test`) pass
- [✓ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ✓] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [✓ ] Frontend Unit tests (`npm test`) pass
- [ ✓] Frontend Test coverage (`npm run coverage`) 100%
- [✓ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [✓ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #32 
