### PR TITLE
add React component for toggling CommonsFeatures

### DIFF
--- a/frontend/src/fixtures/commonsFeaturesFixtures.js
+++ b/frontend/src/fixtures/commonsFeaturesFixtures.js
@@ -1,0 +1,12 @@
+const commonsFeaturesFixtures = {
+  singleFeature: {
+    FARMERS_CAN_SEE_LEADERBOARD: false,
+  },
+  threeFeatures: {
+    FARMERS_CAN_SEE_LEADERBOARD: false,
+    FARMERS_CAN_SEE_HERD_SIZE_HISTOGRAM: true,
+    TAXES_ON_HERD_SIZE_ARE_ENABLED: false,
+  },
+};
+
+export default commonsFeaturesFixtures;

--- a/frontend/src/main/components/Commons/CommonsFeaturesForm.jsx
+++ b/frontend/src/main/components/Commons/CommonsFeaturesForm.jsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from "react";
+import { Form, Button, Row, Col } from "react-bootstrap";
+
+export default function CommonsFeaturesForm({
+  features = {},
+  onSubmit,
+  buttonLabel = "Save",
+}) {
+  const [localFeatures, setLocalFeatures] = useState({});
+
+  useEffect(() => {
+    setLocalFeatures({ ...features });
+  }, [features]);
+
+  const handleCheckboxChange = (featureName) => {
+    setLocalFeatures((prev) => ({
+      ...prev,
+      [featureName]: !prev[featureName],
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onSubmit) {
+      onSubmit(localFeatures);
+    }
+  };
+
+  const formatFeatureName = (featureName) => {
+    return featureName
+      .split("_")
+      .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+      .join(" ");
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Row>
+        {Object.keys(localFeatures).map((featureName) => (
+          <Col key={featureName} md={6} className="mb-3">
+            <Form.Group>
+              <Form.Check
+                type="checkbox"
+                id={featureName}
+                label={formatFeatureName(featureName)}
+                checked={localFeatures[featureName] || false}
+                onChange={() => handleCheckboxChange(featureName)}
+                data-testid={`CommonsFeaturesForm-${featureName}`}
+              />
+            </Form.Group>
+          </Col>
+        ))}
+      </Row>
+      <Row>
+        <Col>
+          <Button
+            type="submit"
+            variant="primary"
+            data-testid="CommonsFeaturesForm-Submit-Button"
+          >
+            {buttonLabel}
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}

--- a/frontend/src/stories/components/Commons/CommonsFeaturesForm.stories.jsx
+++ b/frontend/src/stories/components/Commons/CommonsFeaturesForm.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { action } from "storybook/actions";
+import CommonsFeaturesForm from "main/components/Commons/CommonsFeaturesForm";
+import commonsFeaturesFixtures from "fixtures/commonsFeaturesFixtures";
+
+export default {
+  title: "components/Commons/CommonsFeaturesForm",
+  component: CommonsFeaturesForm,
+};
+
+const Template = (args) => {
+  return <CommonsFeaturesForm {...args} />;
+};
+
+export const SingleFeature = Template.bind({});
+SingleFeature.args = {
+  features: commonsFeaturesFixtures.singleFeature,
+  onSubmit: action("onSubmit"),
+};
+
+export const ThreeFeatures = Template.bind({});
+ThreeFeatures.args = {
+  features: commonsFeaturesFixtures.threeFeatures,
+  onSubmit: action("onSubmit"),
+};

--- a/frontend/src/tests/components/Commons/CommonsFeaturesForm.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsFeaturesForm.test.jsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import CommonsFeaturesForm from "main/components/Commons/CommonsFeaturesForm";
+import commonsFeaturesFixtures from "fixtures/commonsFeaturesFixtures";
+import { vi } from "vitest";
+
+describe("CommonsFeaturesForm tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders correctly with single feature", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.singleFeature}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-FARMERS_CAN_SEE_LEADERBOARD"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Farmers Can See Leaderboard"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-Submit-Button"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-Submit-Button"),
+    ).toHaveTextContent("Save");
+  });
+
+  it("renders correctly with multiple features", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.threeFeatures}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-FARMERS_CAN_SEE_LEADERBOARD"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        "CommonsFeaturesForm-FARMERS_CAN_SEE_HERD_SIZE_HISTOGRAM",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-TAXES_ON_HERD_SIZE_ARE_ENABLED"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText("Farmers Can See Leaderboard"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Farmers Can See Herd Size Histogram"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Taxes On Herd Size Are Enabled"),
+    ).toBeInTheDocument();
+  });
+
+  it("formats feature names correctly", () => {
+    const onSubmit = vi.fn();
+    const features = {
+      FARMERS_CAN_SEE_LEADERBOARD: false,
+      SOME_OTHER_FEATURE: true,
+    };
+
+    render(
+      <CommonsFeaturesForm features={features} onSubmit={onSubmit} />,
+    );
+
+    expect(screen.getByLabelText("Farmers Can See Leaderboard")).toBeInTheDocument();
+    expect(screen.getByLabelText("Some Other Feature")).toBeInTheDocument();
+  });
+
+  it("handles checkbox changes correctly", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.singleFeature}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const checkbox = screen.getByTestId(
+      "CommonsFeaturesForm-FARMERS_CAN_SEE_LEADERBOARD",
+    );
+
+    // Initially false
+    expect(checkbox).not.toBeChecked();
+
+    // Click to toggle
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    // Click again to toggle back
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("calls onSubmit with updated features when form is submitted", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.singleFeature}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const checkbox = screen.getByTestId(
+      "CommonsFeaturesForm-FARMERS_CAN_SEE_LEADERBOARD",
+    );
+    const submitButton = screen.getByTestId(
+      "CommonsFeaturesForm-Submit-Button",
+    );
+
+    // Toggle the checkbox
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    // Submit the form
+    fireEvent.click(submitButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      FARMERS_CAN_SEE_LEADERBOARD: true,
+    });
+  });
+
+  it("does not call onSubmit if onSubmit is not provided", () => {
+    render(
+      <CommonsFeaturesForm features={commonsFeaturesFixtures.singleFeature} />,
+    );
+
+    const submitButton = screen.getByTestId(
+      "CommonsFeaturesForm-Submit-Button",
+    );
+
+    // Submit the form - should not throw
+    fireEvent.click(submitButton);
+  });
+
+  it("uses custom button label when provided", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.singleFeature}
+        onSubmit={onSubmit}
+        buttonLabel="Update Features"
+      />,
+    );
+
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-Submit-Button"),
+    ).toHaveTextContent("Update Features");
+  });
+
+  it("updates local state when features prop changes", () => {
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <CommonsFeaturesForm
+        features={commonsFeaturesFixtures.singleFeature}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const checkbox = screen.getByTestId(
+      "CommonsFeaturesForm-FARMERS_CAN_SEE_LEADERBOARD",
+    );
+    expect(checkbox).not.toBeChecked();
+
+    // Update features prop
+    rerender(
+      <CommonsFeaturesForm
+        features={{ FARMERS_CAN_SEE_LEADERBOARD: true }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(checkbox).toBeChecked();
+  });
+
+  it("handles empty features object", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CommonsFeaturesForm features={{}} onSubmit={onSubmit} />,
+    );
+
+    // Should render without crashing
+    expect(
+      screen.getByTestId("CommonsFeaturesForm-Submit-Button"),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/tests/components/Commons/CommonsFeaturesForm.test.jsx
+++ b/frontend/src/tests/components/Commons/CommonsFeaturesForm.test.jsx
@@ -70,11 +70,11 @@ describe("CommonsFeaturesForm tests", () => {
       SOME_OTHER_FEATURE: true,
     };
 
-    render(
-      <CommonsFeaturesForm features={features} onSubmit={onSubmit} />,
-    );
+    render(<CommonsFeaturesForm features={features} onSubmit={onSubmit} />);
 
-    expect(screen.getByLabelText("Farmers Can See Leaderboard")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Farmers Can See Leaderboard"),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Some Other Feature")).toBeInTheDocument();
   });
 
@@ -187,9 +187,7 @@ describe("CommonsFeaturesForm tests", () => {
 
   it("handles empty features object", () => {
     const onSubmit = vi.fn();
-    render(
-      <CommonsFeaturesForm features={{}} onSubmit={onSubmit} />,
-    );
+    render(<CommonsFeaturesForm features={{}} onSubmit={onSubmit} />);
 
     // Should render without crashing
     expect(
@@ -197,4 +195,3 @@ describe("CommonsFeaturesForm tests", () => {
     ).toBeInTheDocument();
   });
 });
-


### PR DESCRIPTION
Depends on #40 (tests pass locally with #40 implemented)

## Overview
<!--A paragraph of the PR and related content-->
Added react component for toggling CommonsFeatures in storybook. Features two stories under Components/Commons/CommonsFeaturesForm, "Single Feature" and "Three Features." Update values by checking/unchecking boxes and clicking 'Save' (these updates are visible in the Actions panel at the bottom of the screen).

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![commonsfeaturesform-storybook](https://github.com/user-attachments/assets/8b834505-cc7a-4abe-b8d6-236d64ffa4e6)

## Tests
<!--Add any additional tests or required tests-->
- [✅] Frontend Unit tests (`npm test`) pass
- [✅] Frontend Test coverage (`npm run coverage`) 100%
- [✅] Frontend Mutation tests (`npx stryker run`) 100% 
- [✅] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #24
